### PR TITLE
Allow ingress annotations to be added

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: IDR submission ticketing system
 name: idr-redmine-tracker
-version: 0.1.0
+version: 0.1.1

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   name: idr-redmine
   labels:
     app: idr-redmine
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: {{ .Values.ingress.host }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,3 +21,4 @@ gmail:
 
 ingress:
   host: localhost
+  annotations: {}


### PR DESCRIPTION
Allows ingress to be customised

Note the chart version is ignored in all our uses, but bumping as best practice.