### PR TITLE
Define startingDeadlineSeconds to handle downtime

### DIFF
--- a/chart/templates/cronjob.yml
+++ b/chart/templates/cronjob.yml
@@ -4,10 +4,11 @@ kind: CronJob
 metadata:
   name: idr-redmine-email
 spec:
-  schedule: "*/5 * * * *"
+  schedule: {{ .Values.gmail.schedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: {{ .Values.gmail.keepSuccessfulJobs }}
   failedJobsHistoryLimit: {{ .Values.gmail.keepFailedJobs }}
+  startingDeadlineSeconds: {{ .Values.gmail.startingDeadlineSeconds }}
   jobTemplate:
     spec:
       template:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,6 +18,13 @@ gmail:
   password:
   keepSuccessfulJobs: 3
   keepFailedJobs: 6
+  schedule: "*/5 * * * *"
+  # There's a bug where if the cronjob is suspended for more than 100
+  # triggers it's disabled:
+  # https://github.com/kubernetes/kubernetes/issues/42649
+  # We can get around this by reducing the time period over which the
+  # suspensions are counted. 6h == 72 * 5m runs
+  startingDeadlineSeconds: 21600
 
 ingress:
   host: localhost


### PR DESCRIPTION
Work around hard-coded limit of 100 failed triggers in Kubernetes CronJob https://github.com/kubernetes/kubernetes/issues/42649

This has been deployed, but the submodule in https://github.com/openmicroscopy/kubernetes-apps still needs to be bumped

This should prevent https://trello.com/c/QXYnreOH/28-redmine-failed-to-pick-up-some-emails occurring again